### PR TITLE
Not display edit event button for past event

### DIFF
--- a/src/pages/EventDetailPage.jsx
+++ b/src/pages/EventDetailPage.jsx
@@ -285,7 +285,7 @@ const EventDetailPage = () => {
           </Flex>
         </Flex>
         <Flex className={classes.headerButtons}>
-          {event && user && user.userId === host._id && (
+          {event && user && user.userId === host._id && date > new Date() && (
             <Button onClick={updateEventModal.open}>Edit Event</Button>
           )}
           <Button


### PR DESCRIPTION
Implement-
Should not display "Edit Event" button on event details page, if event already happened in the past.

closes #71 